### PR TITLE
Nala CI/CD Debugging

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -20,6 +20,7 @@ jobs:
         uses: ./
         env:
           labels: ${{ inputs.tags }}
+          reporter: html
           IMS_EMAIL: ${{ secrets.IMS_EMAIL }}
           IMS_PASS: ${{ secrets.IMS_PASS }}
       - name: Nala Reporting

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 TAGS=""
+REPORTER=""
 
 # Convert github labels to tags that can be grepped
 for label in ${labels}
@@ -11,11 +12,16 @@ done
 # Remove the first pipe from tags if tags are not empty
 [[ ! -z "$TAGS" ]] && TAGS="${TAGS:1}" && TAGS="-g $TAGS"
 
+# Retrieve github reporter parameter if not empty
+# Otherwise use reporter settings in playwright.config.js
+REPORTER=$reporter
+[[ ! -z "$REPORTER" ]] && REPORTER="--reporter $REPORTER"
+
 echo "*** Running Nala on $branch ***"
 echo $TAGS
-echo "npx playwright test ${TAGS}"
+echo "npx playwright test ${TAGS} ${REPORTER}"
 
 cd $GITHUB_ACTION_PATH
 npm ci
 npx playwright install --with-deps
-npx playwright test ${TAGS}
+npx playwright test ${TAGS} ${REPORTER}


### PR DESCRIPTION
- added debug.yml workflow to provide on-demand execution only for HTML reporting results from playwright test executions for specific branches and tags.  The report artifact is uploaded to GitHub actions and can be downloaded to be used against Playwright's Trace Viewer
- added reporter variable to debug.yml workflow 
- added reporter variable setting to run.sh, the execution can use the HTML reporter if desired, otherwise, it will use the test suite's default reporter set in playwright config.

Resolves: [MWPW-122172](https://jira.corp.adobe.com/browse/MWPW-122172)