### PR TITLE
Added options to run tests against localhost.

### DIFF
--- a/envs/envs.js
+++ b/envs/envs.js
@@ -6,4 +6,6 @@ module.exports = {
   '@acrobat': 'https://main--acrobat--adobecom.hlx.live',
   '@bacom_prod': 'https://business.adobe.com',
   '@blog': 'https://main--blog--adobe.hlx.live',
+  '@local3000': 'http://localhost:3000',
+  '@local6456': 'http://localhost:6456',
 };

--- a/runLocalRegression.sh
+++ b/runLocalRegression.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# This script allows users to run regression tests against localhost
+T_FLAG=''
+H_FLAG=''
+B_FLAG=''
+P_FLAG=3000
+
+Help() {
+  echo "This script allows users to run regression tests against localhost.\n"
+  echo "Options:"
+  echo "-t Tag name. Default=all.\n 
+  ie. ./runLocalRegression.sh -t @modal\n"
+  echo "-h Headed mode. Defaults to headless.\n
+  ie. ./runLocalRegression.sh -h headed\n"
+  echo "-b Project(browser) name. Default=all.\n 
+  ie. ./runLocalRegression.sh -b webkit\n"
+  echo "-p Localhost port. Defaults to localhost:3000.\n
+  ie. ./runLocalRegression.sh -p 6456\n"
+}
+
+while getopts 't:h:b:p:' flag; do
+  case ${flag} in
+    t) T_FLAG=$OPTARG;;
+    h) H_FLAG=--$OPTARG;;
+    b) B_FLAG=--project=$OPTARG;;
+    p) P_FLAG=$OPTARG;;
+    *) Help 
+       exit 1 ;;
+  esac
+done
+
+echo "Setting envs to local"
+sed -i "" "/envs:/s/^/      envs: '@local$P_FLAG', \/\//" ./features/*.js
+
+echo "Executing tests against localhost:$P_FLAG"
+if [ ! -z "$T_FLAG" ]
+then
+  npm test -- -g $T_FLAG $H_FLAG $B_FLAG
+else
+  npm test --  $H_FLAG $B_FLAG
+fi
+
+echo "Reverting envs back to original values"
+sed -i "" "s/envs: '@local$P_FLAG', \/\/      //g" ./features/*.js


### PR DESCRIPTION
Adding options to run Nala tests against localhost 3000 and 6456. 
Ticket: https://jira.corp.adobe.com/browse/MWPW-119683  

In order to test against localhost, the user would have to run the runLocalRegression.sh script. If they don't specify a tag with the -t flag, it'll run all tests. If the 6456 port isn't specified with the -p flag, it'll default to port 3000. 

What the script does: 
1. Updates the envs line in ".feature" files to add either "@localhost:3000" or "@localhost:6456" and comments the existing value out. 
2. It then runs the tests against localhost.
3. It then reverts the envs back to their previous value. 