### PR TITLE
FaaS Test Timeout Fix

### DIFF
--- a/envs/envs.js
+++ b/envs/envs.js
@@ -1,5 +1,6 @@
 module.exports = {
   '@milo': 'https://main--milo--adobecom.hlx.live',
+  '@milo_prod': 'https://milo.adobe.com/',
   '@bacom': 'https://main--bacom--adobecom.hlx.live',
   '@bacomblog': 'https://main--business-website--adobe.hlx.live',
   '@stock': 'https://main--stock--adobecom.hlx.live',

--- a/features/faas.spec.js
+++ b/features/faas.spec.js
@@ -16,7 +16,7 @@ module.exports = {
         '/test/features/blocks/faas-rfi',
         '/test/features/blocks/faas-do',
       ],
-      envs: '@milo',
+      envs: '@milo_prod',
       tags: '@faas-form',
     },
   ],

--- a/tests/faas.test.js
+++ b/tests/faas.test.js
@@ -9,7 +9,7 @@ const selectors = require('../selectors/faas.selectors.js');
 const { name, features } = parse(faas);
 test.describe(`${name}`, () => {
   features.forEach((props) => {
-    test(props.title, async ({ page, browser }) => {
+    test(props.title, async ({ page }) => {
       await page.goto(props.url);
 
       // Fill out form
@@ -43,16 +43,11 @@ test.describe(`${name}`, () => {
       const formOverlay = page.locator(selectors['@form-overlay']);
       await expect(formOverlay).toBeVisible();
 
-      // Only check thank you page on Milo domain, where BACOM hasn't been fully setup for FaaS
-      // Add conditional where FaaS times out with submission request with playwright webkit browser
-      // Remove once we know what causes timeout
-      if (browser.browserType().name() !== 'webkit') {
-        if (props.url.includes('faas-rfi') || props.url.includes('faas-do')) {
-          test.setTimeout(300000);
-          await page.waitForURL(/.*thank-you/);
-          await expect(page).toHaveURL(/.*thank-you/);
-          await expect(page).toHaveTitle(/Thank you\.*.*/);
-        }
+      // Only check thank you page on Milo domain, where BACOM staging hasn't been fully setup
+      if (props.url.includes('faas-rfi') || props.url.includes('faas-do')) {
+        await page.waitForURL(/.*thank-you/);
+        await expect(page).toHaveURL(/.*thank-you/);
+        await expect(page).toHaveTitle(/Thank you\.*.*/);
       }
     });
   });


### PR DESCRIPTION
removed test to remove long timeouts by changing milo environment testing to milo prod.  Removed webkit conditional as well now that it is on prod.