### PR TITLE
Failed block fix for webkit executions

### DIFF
--- a/tests/failedblock.test.js
+++ b/tests/failedblock.test.js
@@ -13,13 +13,13 @@ test.describe(`${name}`, () => {
     test(props.title, async ({ page }) => {
       await page.goto(props.url);
       await page.locator('footer').hover(); // Added to give time for failed block JS to load. Without it, test becomes flaky.
-      const locator = await page.locator(selectors[props.tag]);
+      const locator = page.locator(selectors[props.tag]);
       const count = await locator.count();
       expect(count).toEqual(0);
       if (count > 0) {
         const handles = await locator.elementHandles();
         for (const handlePromise of handles) {
-          const handle = await handlePromise;
+          const handle = handlePromise;
           const reason = await handle.getAttribute('data-reason');
           console.log(`${reason} on ${props.url}`);
         }

--- a/tests/failedblock.test.js
+++ b/tests/failedblock.test.js
@@ -8,20 +8,47 @@ const selectors = require('../selectors/failedblock.selectors.js');
 // Parse the feature file into something flat that can be tested separately
 const { name, features } = parse(failedBlock);
 
+/**
+ * Slow/fast scroll JS evaluation method.
+ * To be used in page.evaluate, i.e. page.evaluate(scroll, { direction: 'value', speed: 'value' });
+ * @param direction string direction you want to scroll
+ * @param speed string speed you would like to scroll. Options: slow, fast
+*/
+const scroll = async (args) => {
+  const { direction, speed } = args;
+  // eslint-disable-next-line no-promise-executor-return
+  const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+  const scrollHeight = () => document.body.scrollHeight;
+  const start = direction === 'down' ? 0 : scrollHeight();
+  const shouldStop = (position) => (direction === 'down' ? position > scrollHeight() : position < 0);
+  const increment = direction === 'down' ? 100 : -100;
+  const delayTime = speed === 'slow' ? 30 : 5;
+  console.error(start, shouldStop(start), increment);
+  for (let i = start; !shouldStop(i); i += increment) {
+    window.scrollTo(0, i);
+    await delay(delayTime);
+  }
+};
+
 test.describe(`${name}`, () => {
   features.forEach((props) => {
-    test(props.title, async ({ page }) => {
+    test(props.title, async ({ page, browser }) => {
       await page.goto(props.url);
-      await page.locator('footer').hover(); // Added to give time for failed block JS to load. Without it, test becomes flaky.
+
+      // Added scrolling for failed block JS to load.
+      // Without it, test provides false count for validation checking.
+      await page.evaluate(scroll, { direction: 'down', speed: 'slow' });
+      await page.evaluate(scroll, { direction: 'up', speed: 'fast' });
+
       const locator = page.locator(selectors[props.tag]);
       const count = await locator.count();
-      expect(count).toEqual(0);
+      expect.soft(count).toEqual(0);
       if (count > 0) {
         const handles = await locator.elementHandles();
         for (const handlePromise of handles) {
           const handle = handlePromise;
           const reason = await handle.getAttribute('data-reason');
-          console.log(`${reason} on ${props.url}`);
+          console.log(`${browser.browserType().name()}: ${reason} on ${props.url}`);
         }
       }
     });


### PR DESCRIPTION
- Removed hover method and instead created scroll method.  The scroll method provides time for all elements to load that lazy load to ensure failedblock.js gets to run for the full page.
- Changed expect() method to expect.soft() so the rest of the test will run if a failed block is found.  This allows the test to still fail if a failed block is found and prints out the browser type, the content of the failed block.