### PR TITLE
Removed workaround for CSP issue

### DIFF
--- a/features/parse.js
+++ b/features/parse.js
@@ -26,7 +26,6 @@ function buildUrl(url, env) {
     if (repoName === 'business-website') { repoName = 'bacomblog'; } // Switch repo name to coincide with env tag naming
   }
   if (env !== `@${repoName}_preview` && env !== `@${repoName}_live`) {
-    if (env.match(/@dc_preview|@dc_live/)) { return url; } // Temporary addition to work around CSP issue
     return `${url}?milolibs=${branch}`;
   }
   return url.replace('main', branch);

--- a/tests/dc_converter.test.js
+++ b/tests/dc_converter.test.js
@@ -56,7 +56,7 @@ test.describe(`${name}`, () => {
   features.forEach((props) => {
     test(props.title, async ({ page, browser }) => {
       const { url } = props;
-      const pageNameRegex = /(?<=online\/)([^.]+)/gi;
+      const pageNameRegex = /(?<=online\/)([^.?]+)/gi;
       const input = fileInputList.filter((x) => x.pages.includes(url.match(pageNameRegex)[0]))[0];
       const converterBlock = page.locator(selectors['@pdf-converter']);
       const fileInput = page.locator(selectors[input.locator]);


### PR DESCRIPTION
Removed workaround for CSP issue with DC hlx.* urls when testing for Milo or any other consuming site but DC's repository.