### PR TITLE
[MWPW-126441] Unblock style-linting by lowercasing all t-shirt sizes in classnames

### DIFF
--- a/selectors/marquee.selectors.js
+++ b/selectors/marquee.selectors.js
@@ -1,7 +1,7 @@
 module.exports = {
   '@marquee-large': '.marquee.large',
   '@medium-button': '.marquee .con-button',
-  '@large-button': '.marquee.large .con-button.button-XL',
+  '@large-button': '.marquee.large .con-button.button-xl',
   '@inline-button': '.marquee.inline .con-button',
   '@marquee-modal-button':
   '//*[contains(@class, "marquee")]//a[contains(@href, "#")]',


### PR DESCRIPTION
* NOTE: This PR relates directly to [#503 in the milo repo](https://github.com/adobecom/milo/pull/503) and SHOULD NOT be merged until the PR in milo is merged and then consumed here.
* Updates all JS files that set classnames to use lowercase t-shirt sizes
* Should allow us to get a clearer picture of style-linting errors moving forward

Resolves: [MWPW-126441](https://jira.corp.adobe.com/browse/MWPW-126441)

**Test URLs:**
(Note that these should both look the same, but the After view uses lowercase t-shirt size classnames)
- Before: https://main--milo--adobecom.hlx.page/docs/library/blocks/media?martech=off
- After: https://ebartholomew-kebab-case-tshirts--milo--adobecom.hlx.page/docs/library/blocks/media?martech=off
