### PR TITLE
HTML extension test uses locale urls

### DIFF
--- a/features/html_ext.spec.js
+++ b/features/html_ext.spec.js
@@ -9,6 +9,7 @@ module.exports = {
         '/customer-success-stories/abb-case-study',
         '/customer-success-stories/dentsu-isobar-case-study',
         '/blog/',
+        '/jp/customer-success-stories/adobe-experience-cloud-case-study',
       ],
       envs: '@bacom_prod',
       tags: '@html',

--- a/tests/html_ext.test.js
+++ b/tests/html_ext.test.js
@@ -62,14 +62,14 @@ test.describe(`${name}`, () => {
         const hrefs = await page.evaluate(() => Array.from(document.links).map((item) => item.href));
         hrefs.forEach(async (linkUrl) => {
           if (!linkUrl.includes('/fragments/')) {
-            if (linkUrl !== 'https://business.adobe.com/blog') {
+            if (!linkUrl.match(/business.adobe.com\/blog|business.adobe.com\/.*\/blog/)) {
               if (linkUrl.charAt(linkUrl.length - 1) === '/') {
                 expect(linkUrl).not.toContain('.html');
               } else {
                 if (linkUrl.includes('business.adobe.com') && !linkUrl.includes('/blog/')) {
                   expect(linkUrl).toContain('.html');
                 }
-                if (linkUrl.includes('business.adobe.com/blog/')) {
+                if (linkUrl.match(/business.adobe.com\/blog\/|business.adobe.com\/.*\/blog\//)) {
                   expect(linkUrl).not.toContain('.html');
                 }
                 if (linkUrl.includes('.html')) {


### PR DESCRIPTION
This PR addresses the found issue in this ticket: [MWPW-127111](https://jira.corp.adobe.com/browse/MWPW-127111)

* Added regex checking for HTML extensions when using locales in /blog/ URLs
* Added JP URL to test HTML extension in a different locale.