### PR TITLE
Daily Run test fixes

### DIFF
--- a/tests/milo/faas.test.js
+++ b/tests/milo/faas.test.js
@@ -10,7 +10,7 @@ const { name, features } = parse(faas);
 test.describe(`${name}`, () => {
   features.forEach((props) => {
     test(props.title, async ({ page, browserName }) => {
-      test.skip(browserName !== 'firefox' && props.tag === '@html', 'Chromium and WebKit browsers are caught by bot checker, working on fix');
+      test.skip(browserName !== 'firefox' && props.tag === '@html-ext', 'Chromium and WebKit browsers are caught by bot checker, working on fix');
       await page.goto(props.url);
 
       // Open up form modal
@@ -44,7 +44,7 @@ test.describe(`${name}`, () => {
       await page.getByLabel(selectors['@zipcode']).fill('77777');
       await page.getByLabel(selectors['@website']).fill('milo.adobe.com');
       await page.getByLabel(selectors['@industry']).selectOption({ label: 'Technology Software & Services' });
-      if (props.tag === '@html') {
+      if (props.tag === '@html-ext') {
         await page.getByLabel(selectors['@company-type']).selectOption({ label: 'Technology or Solution Provider' });
       }
 
@@ -58,7 +58,7 @@ test.describe(`${name}`, () => {
         await page.waitForURL(/.*thank-you/);
         await expect(page).toHaveURL(/.*thank-you/);
         await expect(page).toHaveTitle(/Thank you\.*.*/);
-      } else if (props.tag === '@html') {
+      } else if (props.tag === '@html-ext') {
         await page.waitForURL(/.*sdk\/holiday-shopping-report/);
         await expect(page).toHaveURL(/.*sdk\/holiday-shopping-report/);
         if (browserName === 'firefox') {

--- a/tests/milo/modal.test.js
+++ b/tests/milo/modal.test.js
@@ -20,12 +20,11 @@ async function checkModalClosed(page) {
 
 test.describe(`${name}`, () => {
   features.forEach((props) => {
-    test(props.title, async ({ page }) => {
+    test(`${props.title} Esc key close`, async ({ page, browserName }) => {
+      test.skip(browserName === 'webkit', 'Closing of modal is broken for Webkit 16.4 (playwright build v1792)');
       await page.goto(props.url);
       const marqueeBtn = page.locator(marqueeSelectors['@marquee-modal-button']);
-      const closeBtn = page.locator(modalSelectors['@close-button']);
 
-      // Closing by pressing the Esc key
       await selectModalBtn(marqueeBtn, page);
 
       /**
@@ -45,8 +44,13 @@ test.describe(`${name}`, () => {
       }
 
       await checkModalClosed(page);
+    });
 
-      // Closing by selecting the close button
+    test(`${props.title} button close`, async ({ page }) => {
+      await page.goto(props.url);
+      const marqueeBtn = page.locator(marqueeSelectors['@marquee-modal-button']);
+      const closeBtn = page.locator(modalSelectors['@close-button']);
+
       await selectModalBtn(marqueeBtn, page);
       const inViewport = await page.evaluate(() => {
         const modalDialog = document.querySelector('.dialog-modal');


### PR DESCRIPTION
fixed failing tests in daily runs:

- FaaS test holiday shopping report conditional name was changed from @html to @html-ext
- Modal test cases were split into two tests so that a test.skip() could be added for one of the tests that fail for webkit due to the current playwright trunk build for v16.4 1792.  The modal doesn't close using the Esc key. 