### PR TITLE
MWPW-128629 : Update github self.yml job run check condition

### DIFF
--- a/.github/workflows/self.yml
+++ b/.github/workflows/self.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   action:
     name: Running tests
-    if: github.event.pull_request.labels.some(label => label.name.startsWith('run-'))
+    if: ${{ contains(join(github.event.pull_request.labels.*.name, ' '), 'run-') }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/self.yml
+++ b/.github/workflows/self.yml
@@ -7,7 +7,8 @@ on:
 jobs:
   action:
     name: Running tests
-    if: contains(github.event.pull_request.labels.*.name, 'run-nala')
+    if: |
+      github.event.pull_request.labels.some(label => label.name.startsWith('run-'))
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/self.yml
+++ b/.github/workflows/self.yml
@@ -7,8 +7,7 @@ on:
 jobs:
   action:
     name: Running tests
-    if: |
-      github.event.pull_request.labels.some(label => label.name.startsWith('run-'))
+    if: github.event.pull_request.labels.some(label => label.name.startsWith('run-'))
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Currently, Nala tests are run if PR has the label: `run-nala`, this is now enhanced to below

Jira : [MWPW-128629](https://jira.corp.adobe.com/browse/MWPW-128629)

User will able to run Nala tests if PR has the any label(s) in below format

- No need to have a separate label: `nala-run` to trigger the test run job
-  PR labels 
     - labels = `run-dc` or` run-nala` or `run-milo` etc  will trigger the test run job and executes tests corresponding all projects specified in config.js
     - labels = `run-milo-live` or `run-nala-milo-live` or `run-dc-stage` or `run-dc-live` etc  will trigger the test run job and executes tests corresponding to projects [ like live, stage etc] of specified in config.js
     - labels = `run-milo-live`, `@carousel-container`, `@smoke`  will trigger the test run job and executes tests corresponding to the given tags for given projects [ like live, stage etc] that are specified in config.js

This PR is a continuation to the changes done as part of [PR-101](https://github.com/adobecom/nala/pull/101)
