### PR TITLE
[MWPW-133606] Updated Aside checks (fix failing checks)

### DIFF
--- a/tests/milo/aside.block.test.js
+++ b/tests/milo/aside.block.test.js
@@ -239,17 +239,12 @@ test.describe('Aside Block test suite', () => {
       await expect(Aside.blackButtonCta).toBeVisible();
       await expect(Aside.linkTextCta).not.toBeVisible();
       expect(await Aside.actionButtons.count()).toEqual(2);
-      // Check Aside block background:
-      const bgdColor = await Aside.asideSplitLarge.evaluate((e) => window.getComputedStyle(e).getPropertyValue('background-color'));
-      expect(bgdColor).toBe(Aside.props.background.lightGrey3);
+      // !Note: Aside Split Large doesn't have default background!
     });
   });
 
-  // !Note: Currently, the aside-split-large-half-dark page cannot
-  //        be published, thus skipping the next test until fixed.
-  //
   // Aside Split Large Half Dark Checks:
-  test.skip(`${features[8].name}, ${features[8].tags}`, async ({ page, baseURL }) => {
+  test(`${features[8].name}, ${features[8].tags}`, async ({ page, baseURL }) => {
     const Aside = new AsideBlock(page);
     console.info(`[Test Page]: ${baseURL}${features[8].path}`);
 


### PR DESCRIPTION
- PR raised in order to fix failing Aside check (`aside-split-large`) & enable another check which was skipped because of technical reasons (`aside-split-large-half-dark`)
- PR raised in scope of ticket [[MWPW-133606](https://jira.corp.adobe.com/browse/MWPW-133606)]: Aside Block: Create Nala Automation Test script.