### PR TITLE
Adding sharepoint editing script

### DIFF
--- a/selectors/bacom-blog/sharepoint.page.js
+++ b/selectors/bacom-blog/sharepoint.page.js
@@ -1,0 +1,49 @@
+import { expect } from '@playwright/test';
+
+/**
+ * A Class that represents sharepoint pages.
+ */
+export default class Sharepoint {
+  constructor(page) {
+    this.page = page;
+    this.iframe = page.frameLocator('iframe[name="WacFrame_Word_0"]');
+    this.insertButton = this.iframe.locator('#Insert');
+    this.insertPageBreakButton = this.iframe.locator('#InsertPageBreak');
+    this.homeButton = this.iframe.locator('#Home');
+    this.undoButton = this.iframe.locator('#UndoRedo > button:first-of-type');
+  }
+
+  /**
+   * @description Adds a page break by selecting the insert page break button under
+   * the inserts tab and then saves the file.
+   */
+  async addPageBreak() {
+    await expect(async () => {
+      await this.insertButton.click();
+      await expect(this.insertPageBreakButton).toBeVisible();
+      await this.insertPageBreakButton.click();
+      await this.homeButton.click();
+      await expect(this.undoButton).toBeVisible();
+      await expect(this.undoButton).toBeEnabled();
+    }).toPass();
+
+    await this.page.keyboard.press('Control+S');
+    await this.page.waitForTimeout(2000);
+  }
+
+  /**
+   * @description Undos the previous change in session by selecting the undo button
+   * under the home tab and then saves the file.
+   */
+  async undoChanges() {
+    if (!this.undoButton.isVisible()) this.homeButton.click();
+
+    await expect(async () => {
+      await this.undoButton.click();
+      await expect(this.undoButton).toBeDisabled();
+    }).toPass();
+
+    await this.page.keyboard.press('Control+S');
+    await this.page.waitForTimeout(2000);
+  }
+}

--- a/tests/bacom-blog/edit-sharepoint-doc.test.js
+++ b/tests/bacom-blog/edit-sharepoint-doc.test.js
@@ -1,0 +1,59 @@
+import { test } from '@playwright/test';
+import fs from 'fs';
+import Sharepoint from '../../selectors/bacom-blog/sharepoint.page.js';
+
+const sharepointBacomBlogDrafts = 'https://adobe.sharepoint.com/sites/BizWeb/Shared%20Documents/Forms/AllItems.aspx';
+const bacomBlogAdminUrl = 'https://admin.hlx.page/status/adobecom/bacom-blog/main/';
+const bacomBlogHlx = 'https://main--bacom-blog--adobecom.hlx.live/';
+const data = JSON.parse(fs.readFileSync('./data/bacom-blog/stagedBlogUrls.json', 'utf8'));
+const testPages = Object.keys(data).map((key) => data[key][1]);
+
+let page;
+let sharepoint;
+
+test.describe('Sharepoint editing', { tag: '@sp' }, async () => {
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+    sharepoint = new Sharepoint(page);
+
+    // TODO: Automated okta login
+    // For now, we need to sign into okta manually
+    await page.goto(sharepointBacomBlogDrafts);
+    await page.waitForTimeout(40000);
+  });
+
+  testPages.forEach(async (url) => {
+    await test(`Editing a docx in sharepoint - ${url} `, async () => {
+      await test.setTimeout(10000 * 1000);
+
+      await test.step('1. Go to the docx.', async () => {
+        const relative = url.replace(bacomBlogHlx, '');
+        const adminPage = `${bacomBlogAdminUrl}${relative}?editUrl=auto`;
+        await page.goto(adminPage);
+        await page.waitForLoadState('domcontentloaded');
+        const adminPageContent = await page.locator('pre').textContent();
+        const docxUrl = JSON.parse(adminPageContent).edit.url;
+
+        console.log(`[Test page]: ${url}`);
+        console.log(`[Admin page]: ${adminPage}`);
+        console.log(`[Docx Url]: ${docxUrl}\n`);
+
+        if (docxUrl === undefined) {
+          console.log(`Unable to find edit url for ${url}\n`);
+          test.skip();
+        }
+
+        await page.goto(docxUrl);
+        await page.waitForLoadState('domcontentloaded');
+      });
+
+      await test.step('2. Make an edit and save.', async () => {
+        await sharepoint.addPageBreak();
+      });
+
+      await test.step('3. Undo the change and save.', async () => {
+        await sharepoint.undoChanges();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adding sharepoint editing script for bacom-blog. 

Ticket: [MWPW-147160](https://jira.corp.adobe.com/browse/MWPW-147160)

This script will:

1. Read the urls from a json file. 
2. Loop through each url. 
3. Go to the admin page to get the sharepoint url. 
4. Go to the sharepoint url.
5. Add a page break and save the file.
6. Undo the change and save the file.

