### PR TITLE
Adding bacomSmoke tag

### DIFF
--- a/features/bacom/event-speakers.spec.js
+++ b/features/bacom/event-speakers.spec.js
@@ -6,7 +6,7 @@ module.exports = {
       name: '@event-speakers',
       path: '/test/features/blocks/event-speakers',
       speakerIdx: 1,
-      tags: '@event-speakers @smoke @regression @bacom',
+      tags: '@event-speakers @smoke @regression @bacom @bacomSmoke',
     },
   ],
 };

--- a/features/bacom/stats.spec.js
+++ b/features/bacom/stats.spec.js
@@ -5,7 +5,7 @@ module.exports = {
       tcid: '0',
       name: '@BACOM-Stats',
       path: '/customer-success-stories/adobe-content-hub-case-study',
-      tags: '@stats @bacom @smoke @regression',
+      tags: '@stats @bacom @smoke @regression @bacomSmoke',
     },
   ],
 };

--- a/features/bacom/tree-view.spec.js
+++ b/features/bacom/tree-view.spec.js
@@ -5,7 +5,7 @@ module.exports = {
       tcid: '1',
       name: '@BACOM-TreeView-Checks',
       path: '/test/features/blocks/tree-view',
-      tags: '@tree-view @smoke @regression @bacom',
+      tags: '@tree-view @smoke @regression @bacom @bacomSmoke',
     },
   ],
 };


### PR DESCRIPTION
Adding a 'bacomSmoke' tag to differentiate the tests from bacom-blog since the tag 'bacom' will pick up the bacom-blog tests as well. 