### PR TITLE
Adding retries to the browserstack sh script.

### DIFF
--- a/runOnBrowserstack.sh
+++ b/runOnBrowserstack.sh
@@ -16,7 +16,7 @@ if [ -f "${CONFIG_FILE_PATH}" ]; then
     echo "*** Running Playwright tests with config: ${CONFIG_FILE_PATH} ***"
     if [ -n "$TAG" ]; then
         echo "Running with TAG: ${TAG}"
-        npx browserstack-node-sdk playwright test --config="${CONFIG_FILE_PATH}" --grep="${TAG}"
+        npx browserstack-node-sdk playwright test --config="${CONFIG_FILE_PATH}" --grep="${TAG}" --retries=2
         exit 0
     else
       npx browserstack-node-sdk playwright test --config="${CONFIG_FILE_PATH}"


### PR DESCRIPTION
Sometimes running on browserstack can be a little slow, which causes intermittent failures. Adding retries to the browserstack sh script.