### PR TITLE
resolve ERR_HTTP2_PROTOCOL_ERROR

### DIFF
--- a/tests/milo/commerce.feature.test.js
+++ b/tests/milo/commerce.feature.test.js
@@ -11,9 +11,7 @@ let COMM;
 test.beforeEach(async ({ page, baseURL, browserName }) => {
   COMM = new CommercePage(page);
   if (browserName === 'chromium') {
-    await page.setExtraHTTPHeaders({
-      'sec-ch-ua': '\"Chromium\";v=\"123\", \"Not:A-Brand\";v=\"8\"',
-    });
+    await page.setExtraHTTPHeaders({ 'sec-ch-ua': '\"Chromium\";v=\"123\", \"Not:A-Brand\";v=\"8\"' });
   }
 
   const skipOn = ['bacom', 'business'];

--- a/tests/milo/commerce.feature.test.js
+++ b/tests/milo/commerce.feature.test.js
@@ -11,7 +11,7 @@ let COMM;
 test.beforeEach(async ({ page, baseURL, browserName }) => {
   COMM = new CommercePage(page);
   if (browserName === 'chromium') {
-    await page.setExtraHTTPHeaders({ 'sec-ch-ua': '\"Chromium\";v=\"123\", \"Not:A-Brand\";v=\"8\"' });
+    await page.setExtraHTTPHeaders({ 'sec-ch-ua': '"Chromium";v="123", "Not:A-Brand";v="8"' });
   }
 
   const skipOn = ['bacom', 'business'];

--- a/tests/milo/commerce.feature.test.js
+++ b/tests/milo/commerce.feature.test.js
@@ -10,15 +10,17 @@ const miloLibs = process.env.MILO_LIBS || '';
 let COMM;
 test.beforeEach(async ({ page, baseURL, browserName }) => {
   COMM = new CommercePage(page);
-  const skipOn = ['bacom', 'business'];
+  if (browserName === 'chromium') {
+    await page.setExtraHTTPHeaders({
+      'sec-ch-ua': '\"Chromium\";v=\"123\", \"Not:A-Brand\";v=\"8\"',
+    });
+  }
 
+  const skipOn = ['bacom', 'business'];
   skipOn.some((skip) => {
     if (baseURL.includes(skip)) test.skip(true, `Skipping the commerce tests for ${baseURL}`);
     return null;
   });
-
-  // Skipping tests for chromium on github actions dut to net::ERR_HTTP2_PROTOCOL_ERROR.
-  if (browserName === 'chromium' && process.env.GITHUB_ACTIONS) test.skip();
 });
 
 test.describe('Commerce feature test suite', () => {

--- a/tests/milo/merchcard.block.test.js
+++ b/tests/milo/merchcard.block.test.js
@@ -10,7 +10,7 @@ test.describe('Milo Merchcard block test suite', () => {
   test.beforeEach(async ({ page, browserName }) => {
     merchCard = new MerchCard(page);
     if (browserName === 'chromium') {
-      await page.setExtraHTTPHeaders({ 'sec-ch-ua': '\"Chromium\";v=\"123\", \"Not:A-Brand\";v=\"8\"' });
+      await page.setExtraHTTPHeaders({ 'sec-ch-ua': '"Chromium";v="123", "Not:A-Brand";v="8"' });
     }
   });
 

--- a/tests/milo/merchcard.block.test.js
+++ b/tests/milo/merchcard.block.test.js
@@ -10,9 +10,7 @@ test.describe('Milo Merchcard block test suite', () => {
   test.beforeEach(async ({ page, browserName }) => {
     merchCard = new MerchCard(page);
     if (browserName === 'chromium') {
-      await page.setExtraHTTPHeaders({
-        'sec-ch-ua': '\"Chromium\";v=\"123\", \"Not:A-Brand\";v=\"8\"',
-      });
+      await page.setExtraHTTPHeaders({ 'sec-ch-ua': '\"Chromium\";v=\"123\", \"Not:A-Brand\";v=\"8\"' });
     }
   });
 

--- a/tests/milo/merchcard.block.test.js
+++ b/tests/milo/merchcard.block.test.js
@@ -7,11 +7,14 @@ let merchCard;
 const miloLibs = process.env.MILO_LIBS || '';
 
 test.describe('Milo Merchcard block test suite', () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page, browserName }) => {
     merchCard = new MerchCard(page);
+    if (browserName === 'chromium') {
+      await page.setExtraHTTPHeaders({
+        'sec-ch-ua': '\"Chromium\";v=\"123\", \"Not:A-Brand\";v=\"8\"',
+      });
+    }
   });
-
-  test.skip(({ browserName }) => browserName === 'chromium', 'Skipping tests for Chrome browser');
 
   // Test 0 : Merch Card (Segment)
   test(`${features[0].name},${features[0].tags}`, async ({ page, baseURL }) => {


### PR DESCRIPTION
Resolving net::ERR_HTTP2_PROTOCOL_ERROR that caused us to skip merch block and commerce tests in chromium.

The request for https://www.adobe.com/federal/commerce/price-literals.json was failing due to the headless mode. Removing HeadlessChrome version from the user agent branding with the header override.
The original header in github actions run:
```
{
      "name": "sec-ch-ua",
      "value": "\"HeadlessChrome\";v=\"123\", \"Not:A-Brand\";v=\"8\", \"Chromium\";v=\"123\""
},
 ```