### PR TITLE
Removing windows from bacom's daily platform matrix.

### DIFF
--- a/.github/workflows/bacom.daily.yml
+++ b/.github/workflows/bacom.daily.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     name: Running tests
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
The bacom's daily windows run is picking up more than the specified tags in the daily run, causing it to run for an hour. 