### PR TITLE
MWPW-157100: Merch card headers as p tags for Accessibility #3080

### DIFF
--- a/selectors/milo/merchcard.block.page.js
+++ b/selectors/milo/merchcard.block.page.js
@@ -38,8 +38,8 @@ export default class Merchcard {
     // merch-card special offers
     this.sepcialOffersImage = this.sepcialOffers.locator('div[slot="bg-image"] img');
     this.sepcialOffersRibbon = this.merchCard.locator('.special-offers-badge');
-    this.sepcialOffersTitleH4 = this.sepcialOffers.locator('h4[slot="detail-m"]').nth(0);
-    this.sepcialOffersTitleH5 = this.sepcialOffers.locator('h5[slot="body-xs"]');
+    this.sepcialOffersTitleH4 = this.sepcialOffers.locator('p[slot="detail-m"]').nth(0);
+    this.sepcialOffersTitleH5 = this.sepcialOffers.locator('div[slot="body-xs"]');
     this.sepcialOffersTitleH3 = this.sepcialOffers.locator('h3[slot="heading-xs"]').nth(0);
 
     this.sepcialOffersDescription1 = this.sepcialOffers.locator('div[slot="body-xs"] p').nth(1);
@@ -53,8 +53,8 @@ export default class Merchcard {
     this.productIcon = this.plans.locator('img');
     this.plansRibbon = this.plans.locator('.plans-badge');
     this.plansCardTitleH3 = this.plans.locator('h3[slot="heading-xs"]');
-    this.plansCardTitleH4 = this.plans.locator('h4[slot="body-xxs"]');
-    this.plansCardTitleH5 = this.plans.locator('h5[slot="body-xxs"]');
+    this.plansCardTitleH4 = this.plans.locator('p[slot="body-xxs"]');
+    this.plansCardTitleH5 = this.plans.locator('p[slot="body-xxs"]');
     this.plansCardDescription1 = this.plans.locator('div[slot="body-xs"] p').nth(1);
     this.plansCardDescription2 = this.plans.locator('div[slot="body-xs"] p').nth(2);
     this.plansCardDescription3 = this.plans.locator('div[slot="body-xs"] p').nth(3);
@@ -73,7 +73,7 @@ export default class Merchcard {
     this.systemRequirementTextLink = this.merchCard.locator('a:has-text("See system requirements")');
 
     this.catalogCardTitleH3 = this.catalog.locator('h3[slot="heading-xs"]');
-    this.catalogCardTitleH4 = this.catalog.locator('h4[slot="body-xxs"]');
+    this.catalogCardTitleH4 = this.catalog.locator('p[slot="body-xxs"]');
     this.catalogCardDescription2 = this.catalog.locator('div[slot="body-xs"] p').nth(2);
     this.seeWhatsIncludedTextLink = this.merchCard.locator('a:has-text("See what’s included")');
     this.learnMoreTextLink = this.merchCard.locator('a:has-text("Learn more")');

--- a/selectors/milo/merchcard.block.page.js
+++ b/selectors/milo/merchcard.block.page.js
@@ -38,9 +38,9 @@ export default class Merchcard {
     // merch-card special offers
     this.sepcialOffersImage = this.sepcialOffers.locator('div[slot="bg-image"] img');
     this.sepcialOffersRibbon = this.merchCard.locator('.special-offers-badge');
-    this.sepcialOffersTitleH4 = this.sepcialOffers.locator('p[slot="detail-m"]').nth(0);
-    this.sepcialOffersTitleH5 = this.sepcialOffers.locator('div[slot="body-xs"]');
-    this.sepcialOffersTitleH3 = this.sepcialOffers.locator('h3[slot="heading-xs"]').nth(0);
+    this.plansCardDetailM = this.sepcialOffers.locator('p[slot="detail-m"]').nth(0);
+    this.sepcialOffersTitlePromoText = this.sepcialOffers.locator('div[slot="body-xs"]');
+    this.specialOffersTitleHeading = this.sepcialOffers.locator('h3[slot="heading-xs"]').nth(0);
 
     this.sepcialOffersDescription1 = this.sepcialOffers.locator('div[slot="body-xs"] p').nth(1);
     this.sepcialOffersDescription2 = this.sepcialOffers.locator('div[slot="body-xs"] p').nth(2);
@@ -52,7 +52,7 @@ export default class Merchcard {
     // merch-card plans locators
     this.productIcon = this.plans.locator('img');
     this.plansRibbon = this.plans.locator('.plans-badge');
-    this.plansCardTitleH3 = this.plans.locator('h3[slot="heading-xs"]');
+    this.plansCardTitleHeadingXS = this.plans.locator('h3[slot="heading-xs"]');
     this.plansCardTitleH4 = this.plans.locator('p[slot="body-xxs"]');
     this.plansCardTitleH5 = this.plans.locator('p[slot="body-xxs"]');
     this.plansCardDescription1 = this.plans.locator('div[slot="body-xs"] p').nth(1);

--- a/selectors/milo/merchcard.block.page.js
+++ b/selectors/milo/merchcard.block.page.js
@@ -36,16 +36,16 @@ export default class Merchcard {
     this.linkText2 = this.segmentDescription2.locator('a').nth(1);
 
     // merch-card special offers
-    this.sepcialOffersImage = this.sepcialOffers.locator('div[slot="bg-image"] img');
-    this.sepcialOffersRibbon = this.merchCard.locator('.special-offers-badge');
+    this.specialOffersImage = this.sepcialOffers.locator('div[slot="bg-image"] img');
+    this.specialOffersRibbon = this.merchCard.locator('.special-offers-badge');
     this.plansCardDetailM = this.sepcialOffers.locator('p[slot="detail-m"]').nth(0);
-    this.sepcialOffersTitlePromoText = this.sepcialOffers.locator('div[slot="body-xs"]');
+    this.specialOffersTitlePromoText = this.sepcialOffers.locator('p[slot="body-xxs"]');
     this.specialOffersTitleHeading = this.sepcialOffers.locator('h3[slot="heading-xs"]').nth(0);
 
-    this.sepcialOffersDescription1 = this.sepcialOffers.locator('div[slot="body-xs"] p').nth(1);
-    this.sepcialOffersDescription2 = this.sepcialOffers.locator('div[slot="body-xs"] p').nth(2);
-    this.sepcialOffersDescription3 = this.sepcialOffers.locator('div[slot="body-xs"] p').nth(3);
-    this.sepcialOffersLinkText3 = this.sepcialOffersDescription3.locator('a').nth(0);
+    this.specialOffersDescription1 = this.sepcialOffers.locator('div[slot="body-xs"] p').nth(1);
+    this.specialOffersDescription2 = this.sepcialOffers.locator('div[slot="body-xs"] p').nth(2);
+    this.specialOffersDescription3 = this.sepcialOffers.locator('div[slot="body-xs"] p').nth(3);
+    this.specialOffersLinkText3 = this.specialOffersDescription3.locator('a').nth(0);
 
     this.seeTermsTextLink = this.merchCard.locator('a:has-text("See terms")');
 
@@ -53,8 +53,7 @@ export default class Merchcard {
     this.productIcon = this.plans.locator('img');
     this.plansRibbon = this.plans.locator('.plans-badge');
     this.plansCardTitleHeadingXS = this.plans.locator('h3[slot="heading-xs"]');
-    this.plansCardTitleH4 = this.plans.locator('p[slot="body-xxs"]');
-    this.plansCardTitleH5 = this.plans.locator('p[slot="body-xxs"]');
+    this.plansCardTitlePromoText = this.plans.locator('p[slot="body-xxs"]');
     this.plansCardDescription1 = this.plans.locator('div[slot="body-xs"] p').nth(1);
     this.plansCardDescription2 = this.plans.locator('div[slot="body-xs"] p').nth(2);
     this.plansCardDescription3 = this.plans.locator('div[slot="body-xs"] p').nth(3);

--- a/tests/milo/merchcard.block.test.js
+++ b/tests/milo/merchcard.block.test.js
@@ -95,9 +95,9 @@ test.describe('Milo Merchcard block test suite', () => {
       await expect(await merchCard.sepcialOffers).toBeVisible();
       await expect(await merchCard.sepcialOffersImage).toBeVisible();
 
-      await expect(await merchCard.sepcialOffersTitleH4).toBeVisible();
-      await expect(await merchCard.sepcialOffersTitleH4).toContainText(data.titleH4);
-      await expect(await merchCard.sepcialOffersTitleH3).toContainText(data.titleH3);
+      await expect(await merchCard.plansCardDetailM).toBeVisible();
+      await expect(await merchCard.plansCardDetailM).toContainText(data.titleH4);
+      await expect(await merchCard.specialOffersTitleHeading).toContainText(data.titleH3);
 
       await expect(await merchCard.sepcialOffersDescription1).toContainText(data.description1);
       await expect(await merchCard.sepcialOffersDescription2).toContainText(data.description2);
@@ -126,8 +126,8 @@ test.describe('Milo Merchcard block test suite', () => {
       await expect(await merchCard.sepcialOffersRibbon).toBeVisible();
       await expect(await merchCard.sepcialOffersRibbon).toContainText(data.badgeText);
 
-      await expect(await merchCard.sepcialOffersTitleH3).toContainText(data.titleH3);
-      await expect(await merchCard.sepcialOffersTitleH4).toContainText(data.titleH4);
+      await expect(await merchCard.specialOffersTitleHeading).toContainText(data.titleH3);
+      await expect(await merchCard.plansCardDetailM).toContainText(data.titleH4);
 
       await expect(await merchCard.sepcialOffersDescription1).toContainText(data.description);
       await expect(await merchCard.seeTermsTextLink).toContainText(data.link1Text);
@@ -163,7 +163,7 @@ test.describe('Milo Merchcard block test suite', () => {
       await expect(await merchCard.plans).toBeVisible();
       await expect(await merchCard.productIcon).toBeVisible();
 
-      await expect(await merchCard.plansCardTitleH3).toContainText(data.titleH3);
+      await expect(await merchCard.plansCardTitleHeadingXS).toContainText(data.titleH3);
       await expect(await merchCard.plansCardTitleH5).toContainText(data.titleH5);
 
       // await expect(await merchCard.price).toContainText(data.price);
@@ -195,7 +195,7 @@ test.describe('Milo Merchcard block test suite', () => {
       await expect(await merchCard.plansRibbon).toBeVisible();
       await expect(await merchCard.plansRibbon).toContainText(data.badgeText);
 
-      await expect(await merchCard.plansCardTitleH3).toContainText(data.titleH3);
+      await expect(await merchCard.plansCardTitleHeadingXS).toContainText(data.titleH3);
       await expect(await merchCard.plansCardTitleH4).toContainText(data.titleH4);
 
       // await expect(await merchCard.price).toContainText(data.price);
@@ -224,7 +224,7 @@ test.describe('Milo Merchcard block test suite', () => {
       await expect(await merchCard.plans).toBeVisible();
       await expect(await merchCard.productIcon).toBeVisible();
 
-      await expect(await merchCard.plansCardTitleH3).toContainText(data.titleH3);
+      await expect(await merchCard.plansCardTitleHeadingXS).toContainText(data.titleH3);
       await expect(await merchCard.plansCardTitleH5).toContainText(data.titleH5);
 
       // await expect(await merchCard.price).toContainText(data.price);
@@ -258,7 +258,7 @@ test.describe('Milo Merchcard block test suite', () => {
       await expect(await merchCard.plansRibbon).toBeVisible();
       await expect(await merchCard.plansRibbon).toContainText(data.badgeText);
 
-      await expect(await merchCard.plansCardTitleH3).toContainText(data.titleH3);
+      await expect(await merchCard.plansCardTitleHeadingXS).toContainText(data.titleH3);
       await expect(await merchCard.plansCardTitleH5).toContainText(data.titleH5);
 
       // await expect(await merchCard.price).toContainText(data.price);


### PR DESCRIPTION
This PR changes the tag names of all headings to `<p>` except for the first heading `<h3>` as per accessibility requirements, as changed in this milo PR: https://github.com/adobecom/milo/pull/3080
