### PR TITLE
Accordion fixes

### DIFF
--- a/selectors/milo/accordion.block.page.js
+++ b/selectors/milo/accordion.block.page.js
@@ -5,8 +5,8 @@ export default class Accordion {
     // accordion locators
     this.accordion = this.page.locator('.accordion-container').nth(nth);
     this.accordionForeground = this.accordion.locator('.foreground');
-    this.accordionHeaders = this.accordion.locator('dt[role=heading]');
-    this.accordionButtons = this.accordion.locator('dt button');
+    this.accordionHeaders = this.accordion.locator('div[role=heading]');
+    this.accordionButtons = this.accordion.locator('button');
     this.accordionButtonIcons = this.accordion.locator('.accordion-icon');
     this.outlineButton = this.accordion.locator('.con-button.outline').nth(nth);
     this.blueButton = this.accordion.locator('.con-button.blue').nth(nth);


### PR DESCRIPTION
[MWPW-168575](https://jira.corp.adobe.com/browse/MWPW-168575) 

The accordion tests are failing due to a change in the tags used. We're no longer using the dt tag, see [PR 3613](https://github.com/adobecom/milo/pull/3613) . 