### PR TITLE
[MWPW-170017][ActionRuns] Update the GitHub Actions to address the vulnerability

### DIFF
--- a/.github/workflows/bacom.daily.yml
+++ b/.github/workflows/bacom.daily.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: lts/*
 
@@ -40,7 +40,7 @@ jobs:
         run: echo "The workflow name is $WORKFLOW_NAME"
 
       - name: Persist JSON Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         if: always()
         with:
           name: nala-results

--- a/.github/workflows/bacom.milolibs.run.yml
+++ b/.github/workflows/bacom.milolibs.run.yml
@@ -54,7 +54,7 @@ jobs:
         run: echo "The workflow name is $WORKFLOW_NAME"
 
       - name: Persist JSON Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         if: always()
         with:
           name: nala-results

--- a/.github/workflows/blog.daily.yml
+++ b/.github/workflows/blog.daily.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: lts/*
         
@@ -38,7 +38,7 @@ jobs:
         run: echo "The workflow name is $WORKFLOW_NAME"
         
       - name: Persist JSON Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         if: always()
         with:
           name: nala-results

--- a/.github/workflows/caas.daily.yml
+++ b/.github/workflows/caas.daily.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: lts/*
         
@@ -38,7 +38,7 @@ jobs:
         run: echo "The workflow name is $WORKFLOW_NAME"
         
       - name: Persist JSON Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         if: always()
         with:
           name: nala-results

--- a/.github/workflows/cc.daily.yml
+++ b/.github/workflows/cc.daily.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: lts/*
         
@@ -38,7 +38,7 @@ jobs:
         run: echo "The workflow name is $WORKFLOW_NAME"
         
       - name: Persist JSON Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         if: always()
         with:
           name: nala-results

--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Run Nala for Trace Viewer ${{ inputs.platform }}
         uses: ./
         env:
@@ -30,7 +30,7 @@ jobs:
           HLX_TKN: ${{ secrets.HLX_TKN }}
           SLACK_WH: ${{ secrets.SLACK_WH }}
       - name: Nala Reporting
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/express.daily.yml
+++ b/.github/workflows/express.daily.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: lts/*
 
@@ -38,7 +38,7 @@ jobs:
         run: echo "The workflow name is $WORKFLOW_NAME"
 
       - name: Persist JSON Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         if: always()
         with:
           name: nala-results

--- a/.github/workflows/feds.daily.yml
+++ b/.github/workflows/feds.daily.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: lts/*
         
@@ -38,7 +38,7 @@ jobs:
         run: echo "The workflow name is $WORKFLOW_NAME"
         
       - name: Persist JSON Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         if: always()
         with:
           name: nala-results

--- a/.github/workflows/helpx.daily.yml
+++ b/.github/workflows/helpx.daily.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: lts/*
         
@@ -38,7 +38,7 @@ jobs:
         run: echo "The workflow name is $WORKFLOW_NAME"
         
       - name: Persist JSON Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         if: always()
         with:
           name: nala-results

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Run Nala ${{ inputs.platform }}
         uses: ./
@@ -30,7 +30,7 @@ jobs:
           HLX_TKN: ${{ secrets.HLX_TKN }}
           SLACK_WH: ${{ secrets.SLACK_WH }}          
       - name: Persist JSON Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         if: always()
         with:
           name: nala-results

--- a/.github/workflows/milo.daily.yml
+++ b/.github/workflows/milo.daily.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Run Nala ${{ matrix.os }}
         uses: ./
         env:
@@ -28,7 +28,7 @@ jobs:
           HLX_TKN: ${{ secrets.HLX_TKN }}
           SLACK_WH: ${{ secrets.SLACK_WH }}
       - name: Persist JSON Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         if: always()
         with:
           name: nala-results

--- a/.github/workflows/milolib.yml
+++ b/.github/workflows/milolib.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Set environment variables
         run: |
@@ -46,7 +46,7 @@ jobs:
           HLX_TKN: ${{ secrets.HLX_TKN }}
           SLACK_WH: ${{ secrets.SLACK_WH }}          
       - name: Persist JSON Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         if: always()
         with:
           name: nala-results

--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -20,6 +20,6 @@ jobs:
         run: npm ci
 
       - name: Run eslint on changed files
-        uses: tj-actions/eslint-changed-files@74f98653675512158746d3136cd2d9326fbfb6e1
+        uses: tj-actions/eslint-changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32
         with:
           config_path: '.eslintrc.js'

--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -10,9 +10,9 @@ jobs:
     name: Running eslint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: 20
 
@@ -20,6 +20,6 @@ jobs:
         run: npm ci
 
       - name: Run eslint on changed files
-        uses: tj-actions/eslint-changed-files@v46.0.1
+        uses: tj-actions/eslint-changed-files@74f98653675512158746d3136cd2d9326fbfb6e1
         with:
           config_path: '.eslintrc.js'

--- a/.github/workflows/run-screendiff.yml
+++ b/.github/workflows/run-screendiff.yml
@@ -21,10 +21,10 @@ jobs:
     
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: lts/*
         

--- a/.github/workflows/saucelabs.yml
+++ b/.github/workflows/saucelabs.yml
@@ -11,9 +11,9 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Run Nala with Saucectl
-        uses: saucelabs/saucectl-run-action@v3
+        uses: saucelabs/saucectl-run-action@cac550018c2e54c6f16a3be57b113649b2a37ec3
         with:
           working-directory: /tests
         env:
@@ -31,7 +31,7 @@ jobs:
           SAUCE_USERNAME: ${{secrets.SAUCE_USERNAME}}
           SAUCE_ACCESS_KEY: ${{secrets.SAUCE_ACCESS_KEY}}
       - name: Persist JSON Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         if: always()
         with:
           name: nala-results

--- a/.github/workflows/self.yml
+++ b/.github/workflows/self.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Run Nala
         uses: ./
         env:
@@ -28,7 +28,7 @@ jobs:
           HLX_TKN: ${{ secrets.HLX_TKN }}
           SLACK_WH: ${{ secrets.SLACK_WH }}
       - name: Persist JSON Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         if: always()
         with:
           name: nala-results

--- a/.github/workflows/uar.daily.yml
+++ b/.github/workflows/uar.daily.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
           node-version: lts/*
         
@@ -45,7 +45,7 @@ jobs:
         run: echo "The workflow name is $WORKFLOW_NAME"
         
       - name: Persist JSON Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
         if: always()
         with:
           name: nala-results


### PR DESCRIPTION
PR Includes

Following this [incident](https://www.wiz.io/blog/github-action-tj-actions-changed-files-supply-chain-attack-cve-2025-30066), we want to harden the security for our Github actions by [pinning actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) to full length commit SHAs. It's the recommended approach in terms of security from Github, and while we won't get any minor versions of OOTB, security and stability are more important than the latest and greatest features in this case.