### PR TITLE
Adding marketo show hide test

### DIFF
--- a/features/milo/marketo.block.spec.js
+++ b/features/milo/marketo.block.spec.js
@@ -61,5 +61,17 @@ module.exports = {
       ],
       tags: '@marketo @marketoEssentialMessage @marketoMessage @milo @smoke @regression',
     },
+    {
+      tcid: '8',
+      name: '@marketo show/hide post form submission',
+      path: ['/drafts/nala/blocks/marketo/show-hide'],
+      tags: '@marketo @marketoShowHide @milo @smoke @regression',
+    },
+    {
+      tcid: '9',
+      name: '@marketo form off param',
+      path: ['/drafts/nala/blocks/marketo/show-hide'],
+      tags: '@marketo @marketoShowHide @marketoFormOff @milo @smoke @regression',
+    },
   ],
 };

--- a/selectors/milo/marketo.block.page.js
+++ b/selectors/milo/marketo.block.page.js
@@ -3,7 +3,7 @@ import { expect } from '@playwright/test';
 const FIRST_NAME = 'firstNameTest';
 const LAST_NAME = 'lastNameTest';
 const PHONE = '415-123-4567';
-const EMAIL = 'test+nosub@adobetest.com';
+const EMAIL = 'test@adobetest.com';
 const COMPANY = 'Adobe';
 const POSTAL_CODE = '94111';
 

--- a/tests/milo/marketo.block.test.js
+++ b/tests/milo/marketo.block.test.js
@@ -347,4 +347,84 @@ test.describe('Marketo block test suite', () => {
       });
     });
   });
+
+  features[8].path.forEach((path) => {
+    test(`8: @marketo show/hide content post form submission, ${features[8].tags}, path: ${path}`, async ({
+      page,
+      baseURL,
+    }) => {
+      const testPage = `${baseURL}${path}${miloLibs}`.toLowerCase();
+      console.info(`[Test Page]: ${testPage}`);
+
+      await test.step('step-1: Go to the Marketo show/hide test page', async () => {
+        await page.goto(testPage);
+        await page.waitForLoadState('domcontentloaded');
+        await expect(page.url()).toBe(testPage);
+        await expect(marketoBlock.email).toBeVisible({ timeout: 10000 });
+      });
+
+      await test.step('step-2: Check that the content is hidden/displayed', async () => {
+        const hiddenContent = page.getByText('shown post form submission');
+        const shownContent = page.getByText('hide post form submission');
+
+        await expect(hiddenContent).toBeHidden();
+        await expect(shownContent).toBeVisible();
+        await expect(hiddenContent).not.toBeVisible();
+      });
+
+      await test.step('step-3: Submit the form', async () => {
+        await marketoBlock.submitEssentialTemplateForm();
+        await expect(marketoBlock.message).toBeVisible({ timeout: 10000 });
+      });
+
+      await test.step('step-4: Check that the content is hidden/displayed', async () => {
+        const shownContent = page.getByText('shown post form submission');
+        const hiddenContent = page.getByText('hide post form submission');
+
+        await expect(hiddenContent).toBeHidden();
+        await expect(shownContent).toBeVisible();
+        await expect(hiddenContent).not.toBeVisible();
+      });
+    });
+  });
+
+  features[9].path.forEach((path) => {
+    test(`9: @marketo form off param, ${features[9].tags}, path: ${path}`, async ({
+      page,
+      baseURL,
+    }) => {
+      const testPage = `${baseURL}${path}${miloLibs}`.toLowerCase();
+      console.info(`[Test Page]: ${testPage}`);
+
+      await test.step('step-1: Go to the Marketo show/hide test page', async () => {
+        await page.goto(testPage);
+        await page.waitForLoadState('domcontentloaded');
+        await expect(page.url()).toBe(testPage);
+        await expect(marketoBlock.email).toBeVisible({ timeout: 10000 });
+      });
+
+      await test.step('step-2: Check that the content is hidden/displayed', async () => {
+        const hiddenContent = page.getByText('shown post form submission');
+        const shownContent = page.getByText('hide post form submission');
+
+        await expect(hiddenContent).toBeHidden();
+        await expect(shownContent).toBeVisible();
+        await expect(hiddenContent).not.toBeVisible();
+      });
+
+      await test.step('step-3: Navigate to the page with the form off param', async () => {
+        const formParam = miloLibs ? '&form=off' : '?form=off';
+        await page.goto(`${testPage}${formParam}`);
+      });
+
+      await test.step('step-4: Check that the content is hidden/displayed', async () => {
+        const shownContent = page.getByText('shown post form submission');
+        const hiddenContent = page.getByText('hide post form submission');
+
+        await expect(hiddenContent).toBeHidden();
+        await expect(shownContent).toBeVisible();
+        await expect(hiddenContent).not.toBeVisible();
+      });
+    });
+  });
 });


### PR DESCRIPTION
[MWPW-173108 
](https://jira.corp.adobe.com/browse/MWPW-173108) 
Adding marketo show hide test. The specified content should be shown and hidden after a successful form submission. 