### PR TITLE
Updating uk form to match content change.

### DIFF
--- a/features/bacom/e2e/marketo.e2e.spec.js
+++ b/features/bacom/e2e/marketo.e2e.spec.js
@@ -9,7 +9,6 @@ module.exports = {
         '/de/',
         '/fr/',
         '/au/',
-        '/uk/',
         '/jp/',
       ],
       tags: '@marketo @bacom @smoke @regression @e2e @homepage',
@@ -18,6 +17,7 @@ module.exports = {
       tcid: '1',
       name: '@marketo essential template',
       path: [
+        '/uk/',
         '/resources/webinars/beyond-the-buzzword-operationalizing-generative-ai-for-growth',
       ],
       tags: '@marketo @marketoEssentialTemplate @bacom @smoke @regression @e2e @resources',


### PR DESCRIPTION
The uk homepage is now using an essentials form. Updating to match the content update. 